### PR TITLE
Do not install ruby-debug on travis-ci.org, it only wastes time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ end
 
 group :development do
   gem 'webrat'
-  gem 'ruby-debug19'
+  gem 'ruby-debug19' unless ENV["CI"]
   gem 'wrong'
   gem 'rspec-rails'
   gem 'selenium-webdriver'


### PR DESCRIPTION
Please see "[Exclude non-essential gems like ruby-debug](http://about.travis-ci.org/docs/user/languages/ruby/)" section for rationale.
