### PR TITLE
migration-update - tag with [5.1]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,8 +266,6 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
     stringex (2.7.1)
-    strong_migrations (0.1.9)
-      activerecord (>= 3.2.0)
     temple (0.8.0)
     thin (1.7.2)
       daemons (~> 1.0, >= 1.0.9)
@@ -335,7 +333,6 @@ DEPENDENCIES
   sitemap_generator
   sqlite3
   stringex
-  strong_migrations
   thin
   uglifier
   validate_url
@@ -343,4 +340,4 @@ DEPENDENCIES
   zurb-foundation
 
 BUNDLED WITH
-   1.14.6
+   1.15.4

--- a/db/migrate/20101231215938_create_projects.rb
+++ b/db/migrate/20101231215938_create_projects.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateProjects < ActiveRecord::Migration
+class CreateProjects < ActiveRecord::Migration[5.1]
   def self.up
     create_table :projects do |t|
       t.string :name

--- a/db/migrate/20110106003935_add_tags_to_projects.rb
+++ b/db/migrate/20110106003935_add_tags_to_projects.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddTagsToProjects < ActiveRecord::Migration
+class AddTagsToProjects < ActiveRecord::Migration[5.1]
   def self.up
     add_column :projects, :tags, :string
   end

--- a/db/migrate/20110106025157_devise_create_members.rb
+++ b/db/migrate/20110106025157_devise_create_members.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class DeviseCreateMembers < ActiveRecord::Migration
+class DeviseCreateMembers < ActiveRecord::Migration[5.1]
   def self.up
     create_table(:members) do |t|
       ## Database authenticatable

--- a/db/migrate/20110106040341_add_membername_to_members.rb
+++ b/db/migrate/20110106040341_add_membername_to_members.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddMembernameToMembers < ActiveRecord::Migration
+class AddMembernameToMembers < ActiveRecord::Migration[5.1]
   def self.up
     add_column :members, :membername, :string
   end

--- a/db/migrate/20110201170554_add_member_id_to_project.rb
+++ b/db/migrate/20110201170554_add_member_id_to_project.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddMemberIdToProject < ActiveRecord::Migration
+class AddMemberIdToProject < ActiveRecord::Migration[5.1]
   def self.up
     add_column :projects, :member_id, :integer
     add_index :projects, :member_id

--- a/db/migrate/20110202181320_add_description_to_projects.rb
+++ b/db/migrate/20110202181320_add_description_to_projects.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddDescriptionToProjects < ActiveRecord::Migration
+class AddDescriptionToProjects < ActiveRecord::Migration[5.1]
   def self.up
     add_column :projects, :description, :text
   end

--- a/db/migrate/20110202203517_add_pointofcontact_to_projects.rb
+++ b/db/migrate/20110202203517_add_pointofcontact_to_projects.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddPointofcontactToProjects < ActiveRecord::Migration
+class AddPointofcontactToProjects < ActiveRecord::Migration[5.1]
   def self.up
     add_column :projects, :pointofcontact, :string
   end

--- a/db/migrate/20110202205923_add_startdate_to_projects.rb
+++ b/db/migrate/20110202205923_add_startdate_to_projects.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddStartdateToProjects < ActiveRecord::Migration
+class AddStartdateToProjects < ActiveRecord::Migration[5.1]
   def self.up
     add_column :projects, :startdate, :datetime
   end

--- a/db/migrate/20110202205940_add_finishdate_to_projects.rb
+++ b/db/migrate/20110202205940_add_finishdate_to_projects.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddFinishdateToProjects < ActiveRecord::Migration
+class AddFinishdateToProjects < ActiveRecord::Migration[5.1]
   def self.up
     add_column :projects, :finishdate, :datetime
   end

--- a/db/migrate/20110202225434_add_firstname_to_members.rb
+++ b/db/migrate/20110202225434_add_firstname_to_members.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddFirstnameToMembers < ActiveRecord::Migration
+class AddFirstnameToMembers < ActiveRecord::Migration[5.1]
   def self.up
     add_column :members, :firstname, :string
   end

--- a/db/migrate/20110202225450_add_lastname_to_members.rb
+++ b/db/migrate/20110202225450_add_lastname_to_members.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddLastnameToMembers < ActiveRecord::Migration
+class AddLastnameToMembers < ActiveRecord::Migration[5.1]
   def self.up
     add_column :members, :lastname, :string
   end

--- a/db/migrate/20110203014531_add_url_to_projects.rb
+++ b/db/migrate/20110203014531_add_url_to_projects.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddUrlToProjects < ActiveRecord::Migration
+class AddUrlToProjects < ActiveRecord::Migration[5.1]
   def self.up
     add_column :projects, :url, :string
   end

--- a/db/migrate/20110214223958_change_column_projects_summary_to_text.rb
+++ b/db/migrate/20110214223958_change_column_projects_summary_to_text.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class ChangeColumnProjectsSummaryToText < ActiveRecord::Migration
+class ChangeColumnProjectsSummaryToText < ActiveRecord::Migration[5.1]
   def self.up
     change_column :projects, :summary, :text
   end

--- a/db/migrate/20110217201007_create_profiles.rb
+++ b/db/migrate/20110217201007_create_profiles.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateProfiles < ActiveRecord::Migration
+class CreateProfiles < ActiveRecord::Migration[5.1]
   def self.up
     create_table :profiles do |t|
       t.integer :member_id

--- a/db/migrate/20110227012754_add_firstname_to_profile.rb
+++ b/db/migrate/20110227012754_add_firstname_to_profile.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddFirstnameToProfile < ActiveRecord::Migration
+class AddFirstnameToProfile < ActiveRecord::Migration[5.1]
   def self.up
     add_column :profiles, :firstname, :string
   end

--- a/db/migrate/20110227012829_add_lastname_to_profile.rb
+++ b/db/migrate/20110227012829_add_lastname_to_profile.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddLastnameToProfile < ActiveRecord::Migration
+class AddLastnameToProfile < ActiveRecord::Migration[5.1]
   def self.up
     add_column :profiles, :lastname, :string
   end

--- a/db/migrate/20110227172229_add_url_to_profiles.rb
+++ b/db/migrate/20110227172229_add_url_to_profiles.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddUrlToProfiles < ActiveRecord::Migration
+class AddUrlToProfiles < ActiveRecord::Migration[5.1]
   def self.up
     add_column :profiles, :url, :string
   end

--- a/db/migrate/20110829180317_add_uri_to_project.rb
+++ b/db/migrate/20110829180317_add_uri_to_project.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddUriToProject < ActiveRecord::Migration
+class AddUriToProject < ActiveRecord::Migration[5.1]
   def self.up
     add_column :projects, :uri, :string
   end

--- a/db/migrate/20110925224904_add_requiredskills_to_projects.rb
+++ b/db/migrate/20110925224904_add_requiredskills_to_projects.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddRequiredskillsToProjects < ActiveRecord::Migration
+class AddRequiredskillsToProjects < ActiveRecord::Migration[5.1]
   def self.up
     add_column :projects, :requiredskills, :string
   end

--- a/db/migrate/20111108165550_add_uri_anchor_to_projects.rb
+++ b/db/migrate/20111108165550_add_uri_anchor_to_projects.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddUriAnchorToProjects < ActiveRecord::Migration
+class AddUriAnchorToProjects < ActiveRecord::Migration[5.1]
   def change
     add_column :projects, :uri_anchor, :string
   end

--- a/db/migrate/20111109154845_add_url_anchor_to_profile.rb
+++ b/db/migrate/20111109154845_add_url_anchor_to_profile.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddUrlAnchorToProfile < ActiveRecord::Migration
+class AddUrlAnchorToProfile < ActiveRecord::Migration[5.1]
   def change
     add_column :profiles, :url_anchor, :string
   end

--- a/db/migrate/20111109155046_remove_url_anchor_to_profile.rb
+++ b/db/migrate/20111109155046_remove_url_anchor_to_profile.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class RemoveUrlAnchorToProfile < ActiveRecord::Migration
+class RemoveUrlAnchorToProfile < ActiveRecord::Migration[5.1]
   def up
     remove_column :profiles, :url_anchor
   end

--- a/db/migrate/20111109162248_add_website_anchor_to_profile.rb
+++ b/db/migrate/20111109162248_add_website_anchor_to_profile.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddWebsiteAnchorToProfile < ActiveRecord::Migration
+class AddWebsiteAnchorToProfile < ActiveRecord::Migration[5.1]
   def change
     add_column :profiles, :website_anchor, :string
   end

--- a/db/migrate/20111117180143_add_gprofile_url_to_profile.rb
+++ b/db/migrate/20111117180143_add_gprofile_url_to_profile.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddGprofileUrlToProfile < ActiveRecord::Migration
+class AddGprofileUrlToProfile < ActiveRecord::Migration[5.1]
   def change
     add_column :profiles, :gprofile_url, :string
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -17,60 +16,58 @@ ActiveRecord::Schema.define(version: 20111117180143) do
   enable_extension "plpgsql"
 
   create_table "members", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
-    t.string   "reset_password_token"
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0
+    t.integer "sign_in_count", default: 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip"
-    t.string   "last_sign_in_ip"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string   "membername"
-    t.string   "firstname"
-    t.string   "lastname"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "membername"
+    t.string "firstname"
+    t.string "lastname"
+    t.index ["email"], name: "index_members_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_members_on_reset_password_token", unique: true
   end
 
-  add_index "members", ["email"], name: "index_members_on_email", unique: true, using: :btree
-  add_index "members", ["reset_password_token"], name: "index_members_on_reset_password_token", unique: true, using: :btree
-
   create_table "profiles", force: :cascade do |t|
-    t.integer  "member_id"
-    t.text     "bio"
-    t.string   "website"
-    t.string   "twitter"
-    t.string   "facebook"
-    t.string   "linkedin"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string   "firstname"
-    t.string   "lastname"
-    t.string   "url"
-    t.string   "website_anchor"
-    t.string   "gprofile_url"
+    t.integer "member_id"
+    t.text "bio"
+    t.string "website"
+    t.string "twitter"
+    t.string "facebook"
+    t.string "linkedin"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "firstname"
+    t.string "lastname"
+    t.string "url"
+    t.string "website_anchor"
+    t.string "gprofile_url"
   end
 
   create_table "projects", force: :cascade do |t|
-    t.string   "name"
-    t.text     "summary"
-    t.string   "client"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string   "tags"
-    t.integer  "member_id"
-    t.text     "description"
-    t.string   "pointofcontact"
+    t.string "name"
+    t.text "summary"
+    t.string "client"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "tags"
+    t.integer "member_id"
+    t.text "description"
+    t.string "pointofcontact"
     t.datetime "startdate"
     t.datetime "finishdate"
-    t.string   "url"
-    t.string   "uri"
-    t.string   "requiredskills"
-    t.string   "uri_anchor"
+    t.string "url"
+    t.string "uri"
+    t.string "requiredskills"
+    t.string "uri_anchor"
+    t.index ["member_id"], name: "index_projects_on_member_id"
   end
-
-  add_index "projects", ["member_id"], name: "index_projects_on_member_id", using: :btree
 
 end


### PR DESCRIPTION
For work reasons, I had to cycle my postgres installation,
hence needed to rebuild the database for the first time
since upgrading to rails 5.1. This was a bit of a hassle
with strong migrations gem installed, so I disabled that
to do the migration.

sed script from SO made the changes, very handy.